### PR TITLE
Accommodate Z shell profiles

### DIFF
--- a/onepassword/utils.py
+++ b/onepassword/utils.py
@@ -18,13 +18,13 @@ def read_bash_return(cmd, single=True):
 def docker_check():
     f = None
     user_home = os.environ.get('HOME')
-    for rcfile in ['.bashrc', '.zshrc']:
+    for rcfile in ['.bashrc', '.bash_profile', '.zshrc', '.zprofile']:
         rcpath = os.path.join(user_home, rcfile)
         if os.path.exists(rcpath):
             f = open(os.path.join(user_home, rcpath), "r")
             break
     if not f:
-        raise Exception("No rc files (.bashrc/.zshrc) exist.")
+        raise Exception("No sehll rc or profile files exist.")
     bash_profile = f.read()
     try:
         docker_flag = bash_profile.split('DOCKER_FLAG="')[1][0]
@@ -86,13 +86,13 @@ class BashProfile:
     def __init__(self):
         f = None
         user_home = os.environ.get('HOME')
-        for rcfile in ['.bashrc', '.zshrc']:
+        for rcfile in ['.bashrc', '.bash_profile', '.zshrc', '.zprofile']:
             rcpath = os.path.join(user_home, rcfile)
             if os.path.exists(rcpath):
                 f = open(os.path.join(user_home, rcpath), "r")
                 break
         if not f:
-            raise Exception("No rc files (.bashrc/.zshrc) exist.")
+            raise Exception("No shell rc or profile files exist.")
         self.other_profile_flag = False
         if docker_check():
             f2 = None

--- a/onepassword/utils.py
+++ b/onepassword/utils.py
@@ -22,8 +22,9 @@ def docker_check():
         rcpath = os.path.join(user_home, rcfile)
         if os.path.exists(rcpath):
             f = open(os.path.join(user_home, rcpath), "r")
+            break
     if not f:
-        raise Exception("rc file does not exist.")
+        raise Exception("No rc files (.bashrc/.zshrc) exist.")
     bash_profile = f.read()
     try:
         docker_flag = bash_profile.split('DOCKER_FLAG="')[1][0]
@@ -89,8 +90,9 @@ class BashProfile:
             rcpath = os.path.join(user_home, rcfile)
             if os.path.exists(rcpath):
                 f = open(os.path.join(user_home, rcpath), "r")
+                break
         if not f:
-            raise Exception("rc file does not exist.")
+            raise Exception("No rc files (.bashrc/.zshrc) exist.")
         self.other_profile_flag = False
         if docker_check():
             f2 = None

--- a/onepassword/utils.py
+++ b/onepassword/utils.py
@@ -17,7 +17,7 @@ def read_bash_return(cmd, single=True):
 
 def docker_check():
     f = None
-    user_home = os.eviron.get('HOME')
+    user_home = os.environ.get('HOME')
     for rcfile in ['.bashrc', '.zshrc']:
         rcpath = os.path.join(user_home, rcfile)
         if os.path.exists(rcpath):

--- a/onepassword/utils.py
+++ b/onepassword/utils.py
@@ -17,14 +17,13 @@ def read_bash_return(cmd, single=True):
 
 def docker_check():
     f = None
-    user_home = read_bash_return("echo $HOME")
-    try:
-        f = open(os.path.join(user_home, ".bashrc"), "r")
-    except IOError:
-        try:
-            f = open(os.path.join(user_home, ".bash_profile"), "r")
-        except IOError:
-            print("Bash profile file does not exist.")
+    user_home = os.eviron.get('HOME')
+    for rcfile in ['.bashrc', '.zshrc']:
+        rcpath = os.path.join(user_home, rcfile)
+        if os.path.exists(rcpath):
+            f = open(os.path.join(user_home, rcpath), "r")
+    if not f:
+        raise Exception("rc file does not exist.")
     bash_profile = f.read()
     try:
         docker_flag = bash_profile.split('DOCKER_FLAG="')[1][0]
@@ -85,14 +84,13 @@ def domain_from_email(address):
 class BashProfile:
     def __init__(self):
         f = None
-        user_home = read_bash_return("echo $HOME")
-        try:
-            f = open(os.path.join(user_home, ".bashrc"), "r")
-        except IOError:
-            try:
-                f = open(os.path.join(user_home, ".bash_profile"), "r")
-            except IOError:
-                print("Bash profile file does not exist.")
+        user_home = os.environ.get('HOME')
+        for rcfile in ['.bashrc', '.zshrc']:
+            rcpath = os.path.join(user_home, rcfile)
+            if os.path.exists(rcpath):
+                f = open(os.path.join(user_home, rcpath), "r")
+        if not f:
+            raise Exception("rc file does not exist.")
         self.other_profile_flag = False
         if docker_check():
             f2 = None


### PR DESCRIPTION
Revised code to accommodate .zsh profiles.

Replaced try/catch in some places with checks to see if the path exists since IOError exceptions may be raised for a variety of reasons.