### PR TITLE
Updated to reuse device_uuid if OP_DEVICE is already set

### DIFF
--- a/onepassword/client.py
+++ b/onepassword/client.py
@@ -3,7 +3,7 @@ import json
 import yaml
 from getpass import getpass
 from json import JSONDecodeError
-from onepassword.utils import read_bash_return, domain_from_email, Encryption, BashProfile, generate_uuid, _spawn_signin
+from onepassword.utils import read_bash_return, domain_from_email, Encryption, BashProfile, get_device_uuid, _spawn_signin
 from onepassword.exceptions import OnePasswordForgottenPassword
 
 
@@ -30,10 +30,8 @@ class OnePassword:
         self.signin_domain = domain
         self.email_address = email
         self.secret_key = secret
-        device_uuid = generate_uuid()
-        os.environ["OP_DEVICE"] = device_uuid
         bp = BashProfile()
-        bp.update_profile("OP_DEVICE", device_uuid)
+        os.environ["OP_DEVICE"] = get_device_uuid(bp)
         # Check first time: if true, full signin, else use shortened signin
         if self.check_not_first_time(bp):
             self.encrypted_master_password, self.session_key = self.signin_wrapper(account=account,

--- a/onepassword/utils.py
+++ b/onepassword/utils.py
@@ -1,5 +1,6 @@
 import os
 import base64
+
 import pexpect
 from Crypto.Cipher import AES
 from Crypto.Util.Padding import pad
@@ -212,3 +213,20 @@ def generate_uuid():
     :return: (str)
     """
     return read_bash_return("head -c 16 /dev/urandom | base32 | tr -d = | tr '[:upper:]' '[:lower:]'")
+
+
+def get_device_uuid(bp):
+    """
+    Attempts to get the device_uuid from the given BashProfile. If the device_uuid is not
+    set in the BashProfile generates a new device_uuid and sets it in the given
+    BashProfile.
+
+    :return: (str)
+    """
+    try:
+        device_uuid = bp.get_key_value("OP_DEVICE")[0]['OP_DEVICE'].strip('"')
+    except AttributeError:
+        device_uuid = generate_uuid()
+        bp.update_profile("OP_DEVICE", device_uuid)
+
+    return device_uuid


### PR DESCRIPTION
This resolves an issue with 1Password believing that every successful login with `OnePassword()` is from a new device by reusing the uuid stored in `OP_DEVICE` if it exists. As a result, 1Password no longer sends emails alerting a new login has been detected.