### PR TITLE
`list_items` function fails when the vault name has a space

### DIFF
--- a/onepassword/client.py
+++ b/onepassword/client.py
@@ -307,7 +307,7 @@ class OnePassword:
         :returns: items :obj:`dict`: dict of all items
 
         """
-        items = json.loads(read_bash_return("op list items --vault={}".format(vault)))
+        items = json.loads(read_bash_return("op list items --vault='{}'".format(vault)))
         return items
 
     @staticmethod


### PR DESCRIPTION
`list_items` function fails when the vault name has space. 
```
[ERROR] 2021/06/29 13:56:37 "Hackweek" doesn't seem to be a vault in this account. Specify the vault with its UUID or name.
```