### PR TITLE
Check op is installed before any filesystem change

### DIFF
--- a/install_op.py
+++ b/install_op.py
@@ -69,6 +69,10 @@ def install_op():  # pragma: no cover
     """
     Helper function to download, unzip, install and chmod op cli files
     """
+
+    if not check_install_required():
+        return
+
     system = str(platform.system())
     machine = str(platform.machine())
     link = platform_links[system][machine]
@@ -84,10 +88,7 @@ def install_op():  # pragma: no cover
         zip_ref.close()
         os.chmod(os.path.join(local_bin, 'op'), 0o755)
     else:
-        if check_install_required():
-            Popen(["open", os.path.join(local_bin, op_file)], stdin=PIPE, stdout=PIPE)  # pragma: no cover
-        else:
-            pass
+        Popen(["open", os.path.join(local_bin, op_file)], stdin=PIPE, stdout=PIPE)  # pragma: no cover
 
 
 def install_chocolatey():


### PR DESCRIPTION
Before this change the package installer would try to modify system
folders before checking whether the changes were necessary.

That would fail unless the installation runs as a priveleged user.

If op is already installed, then we can avoid the problem.

Fixes: https://github.com/wandera/1password-client/issues/25