### PR TITLE
Fixed issue with catching the incorrect exception in get_device_uuid

### DIFF
--- a/onepassword/utils.py
+++ b/onepassword/utils.py
@@ -227,7 +227,7 @@ def get_device_uuid(bp):
     """
     try:
         device_uuid = bp.get_key_value("OP_DEVICE")[0]['OP_DEVICE'].strip('"')
-    except AttributeError:
+    except ValueError:
         device_uuid = generate_uuid()
         bp.update_profile("OP_DEVICE", device_uuid)
 


### PR DESCRIPTION
The function get_device_uuid was configured to catch an _AttributeError_ if **OP_DEVICE** didn't exist in the BashProfile. However, get_key_value raises a _ValueError_ when **OP_DEVICE** didn't exist in the BashProfile. This PR fixes this issue.