### PR TITLE
Updated get_device_uuid to catch ValueError

### DIFF
--- a/onepassword/utils.py
+++ b/onepassword/utils.py
@@ -227,7 +227,7 @@ def get_device_uuid(bp):
     """
     try:
         device_uuid = bp.get_key_value("OP_DEVICE")[0]['OP_DEVICE'].strip('"')
-    except AttributeError:
+    except (AttributeError, ValueError):
         device_uuid = generate_uuid()
         bp.update_profile("OP_DEVICE", device_uuid)
 


### PR DESCRIPTION
Calls to `BashProfile.get_key_value` can cause either an `AttributeError` or a `ValueError` to be raised if the requested **key** is not in the _rcfile_.  If the _rcfile_ is not empty and the **key** isn't found in it then an `AttributeError` is raised when trying to call the _replace_ method on _None_: https://github.com/wandera/1password-client/blob/0702743b2151267996c08e01b73a21810231ec37/onepassword/utils.py#L141-L147
If the _rcfile_ is empty then a `ValueError` is raised because `BashProfile.get_key_line` returns an empty list: https://github.com/wandera/1password-client/blob/0702743b2151267996c08e01b73a21810231ec37/onepassword/utils.py#L120-L130

This PR updates `get_device_uuid` to catch both `AttributeError` and `ValueError` so the package will work for users that have an empty _rcfile_.