### PR TITLE
Add handling for fields with spaces

### DIFF
--- a/onepassword/client.py
+++ b/onepassword/client.py
@@ -330,9 +330,9 @@ class OnePassword:
 
         """
         if isinstance(fields, list):
-            item = json.loads(read_bash_return("op get item {} --fields {}".format(uuid, ",".join(fields))))
+            item = json.loads(read_bash_return("op get item {} --fields \"{}\"".format(uuid, ",".join(fields))))
         elif isinstance(fields, str):
-            item = {fields: read_bash_return("op get item {} --fields {}".format(uuid, fields))}
+            item = {fields: read_bash_return("op get item {} --fields \"{}\"".format(uuid, fields))}
         else:
             item = json.loads(read_bash_return("op get item {}".format(uuid)))
         return item


### PR DESCRIPTION
Assuming a vault entry with ID "abc" and fields called "API Key" and "API Secret", the following command fails:

```
op.get_item("abc", ["API Key", "API Secret"])
```

The following traceback is thrown:
```
 File "/Users/traviscook/git_repos/money/.venv/lib/python3.10/site-packages/onepassword/client.py", line 333, in get_item
    item = json.loads(read_bash_return("op get item {} --fields {}".format(uuid, ",".join(fields))))
  File "/usr/local/Cellar/python@3.10/3.10.2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/local/Cellar/python@3.10/3.10.2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/local/Cellar/python@3.10/3.10.2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

This occurs because the library ultimately sends this command:
```
op get item abc --fields API Key,API Secret
```

This isn't properly escaped for a shell.  It should be:
```
op get item abc --fields "API Key,API Secret"
```

This commit fixes this behavior.