### PR TITLE
feat: add support for read CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,30 @@ op = OnePassword()
 op.list_vaults()
 ```
 
+### Secret References
+
+Secret references are direct keys to a field in an item. They are useful when trying to get only one field(ex. API Key or a password) from an item.
+
+You can fetch secret based on secret references with the following code:
+
+```python
+from onepassword import OnePassword
+
+op = OnePassword()
+op.read("op://<vault>/<item>/<field>")
+```
+
+You can get the secret reference in one of the supported ways explained here:
+https://developer.1password.com/docs/cli/secret-references/
+
+Or you can use this:
+```python
+from onepassword import OnePassword
+
+op = OnePassword()
+op.get_item("Item")["fields"][0]['reference']
+```
+
 ### Input formats
 To be sure what you are using is of the right format
 
@@ -165,6 +189,7 @@ This is the set of commands the current python SDK covers:
 - list: List objects and events
     - items
     - vaults
+- read: Get a secret based on a secret reference
 - signin: Sign in to a 1Password account
 - signout: Sign out of a 1Password account
 

--- a/onepassword/client.py
+++ b/onepassword/client.py
@@ -451,6 +451,21 @@ class OnePassword:
         return item
 
     @staticmethod
+    def read(secret_ref: str):
+        """
+        Helper function to read a secret based on its reference(ex: op://<vault>/<item>/<field>)
+        You can get this reference from the UI or by using this command:
+        op item get <item> --format json --fields <secret_field>
+
+        :param secret_ref: Reference to the secret you wish to read
+        :return: The secret in plain text
+        """
+        if not secret_ref or not isinstance(secret_ref, str):
+            raise ValueError("secret_ref must be a non-empty string")
+
+        return read_bash_return("op read '{}'".format(secret_ref))
+
+    @staticmethod
     def get_item_otp(uuid: str | bytes):
         """
         Helper function to get the item otp, you can find the UUID you need using list_items


### PR DESCRIPTION
inspired by [adnandaut](https://github.com/adnandaut) and my needs.

fixes #66 by adding support for the read CLI command

this can be tested like this:
```
>>> from onepassword import OnePassword
>>> OnePassword.read("<a secret reference>")
```