### PR TITLE
Fix reading multiline secrets (e.g. files) with op.read()

### DIFF
--- a/onepassword/client.py
+++ b/onepassword/client.py
@@ -465,7 +465,7 @@ class OnePassword:
         if not secret_ref or not isinstance(secret_ref, str):
             raise ValueError("secret_ref must be a non-empty string")
 
-        return read_bash_return("op read '{}'".format(secret_ref))
+        return read_bash_return("op read '{}'".format(secret_ref), single=False).removesuffix('\n')
 
     @staticmethod
     def get_item_otp(uuid: str | bytes):


### PR DESCRIPTION
- Resolves #73 

Side note:
I noticed that other places in the code use `rstrip('\n')`.
But if an attached file acually ends with one or more line breaks, I think we want to leave them as they are and only remove the single trailing newline that the `op` cli tool adds as a convenience for interactive use in the shell.
For this, the method [removesuffix](https://docs.python.org/3/library/stdtypes.html#str.removesuffix), introduced in Python 3.9, is used instead of `rstrip`, which removes all trailing linebreaks.

Since I do not have enough context for the other usages of `rstrip` in the code, I can not say for certain, but I would think that they could also utilise `removesuffix` instead.